### PR TITLE
Allow for aborts in attempted function

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In your project folder, type:
 ## Usage
 Whenever you have code that looks like this:
 
-	function flakyApiCall(function(err, result) {
+	flakyApiCall(function(err, result) {
 	    if (err)
 	        console.log('Flaky API died AGAIN!', err);
 	    else
@@ -21,17 +21,42 @@ Whenever you have code that looks like this:
 
 Just drop that code in an attempt!
 
-	var attempt = require('attempt');
-	attempt(
-		function() {
-			flakyApiCall(this);
-		},
-		function(err, result) {
-	        if (err)
-	            console.log('Flaky API failed 3 times.', err);
-	        else
-	            doSomething(result);
-	    });
+	  var attempt = require('attempt');
+	  attempt(
+	      function() {
+	          flakyApiCall(this);
+	      },
+	      function(err, result) {
+	          if (err)
+                console.log('Flaky API failed 3 times.', err);
+	          else
+	              doSomething(result);
+	      }
+    );
+
+Sometimes you know an error will repeat itself and you might want to stop
+doing any further attempts:
+
+	  var attempt = require('attempt');
+	  attempt(
+	      function() {
+            var callback = this;
+	          flakyApiCall(function (err, result) {
+                if (err && err.code === 500)
+                    callback.abort(err);
+                else if (err)
+                    callback(err);
+                else
+                    callback(err, result);
+            });
+	      },
+	      function(err, result) {
+	          if (err)
+                console.log('Flaky API failed 3 times.', err);
+	          else
+	              doSomething(result);
+	      }
+    );
 
 ## Details
 Attempt will re-run your attempted function if it throws an error or if it

--- a/lib/attempt.js
+++ b/lib/attempt.js
@@ -70,7 +70,7 @@ function attempt(options, tryFunc, callback) {
 			if (respectInterval && options.retries && options.interval) {
 				var timeout = Math.min(
 					(1 + options.random * Math.random()) *
-						options.interval * 
+						options.interval *
 						Math.pow(options.factor, options.attempts),
 					options.max);
 				setTimeout(runAgain, timeout);
@@ -101,6 +101,12 @@ function attempt(options, tryFunc, callback) {
 			if (args[0]) handleError(args[0]);
 			else if (callback) callback.apply(null, args);
 		}
+
+    assess.abort = function (err) {
+      options.retries = 0;
+      assess(err);
+    };
+
 		// Call it cap'n.
 		try {
 			tryFunc.call(assess, options.attempts);
@@ -154,7 +160,7 @@ attempt.defaults = {
 	 * @type {Number}
 	 */
 	attempts: 0,
- 
+
 	/**
 	 * The maximum number of milliseconds to wait before retrying.  If the
 	 * interval or factor causes a wait time larger than 'max', 'max' will

--- a/test/lib.attempt.js
+++ b/test/lib.attempt.js
@@ -200,4 +200,17 @@ describe('Attempt', function() {
 				done();
 			});
 	});
+	it('should stop attempting after an abort', function(done) {
+		var attempts = 0;
+		attempt(
+      function(_) {
+        attempts++;
+				this.abort("fail now!");
+			},
+			function(err) {
+				err.should.eql("fail now!");
+        attempts.should.eql(1);
+				done();
+			});
+	});
 });


### PR DESCRIPTION
Within attempted functions, `this` now exposes an `abort()` method that accepts an error. Calling it will make _attempt_ stop trying and fail right away.
