### PR TITLE
We should not handle assertions in final callback

### DIFF
--- a/lib/attempt.js
+++ b/lib/attempt.js
@@ -70,7 +70,7 @@ function attempt(options, tryFunc, callback) {
 			if (respectInterval && options.retries && options.interval) {
 				var timeout = Math.min(
 					(1 + options.random * Math.random()) *
-						options.interval * 
+						options.interval *
 						Math.pow(options.factor, options.attempts),
 					options.max);
 				setTimeout(runAgain, timeout);
@@ -99,7 +99,7 @@ function attempt(options, tryFunc, callback) {
 		function assess() {
 			var args = Array.prototype.slice.call(arguments);
 			if (args[0]) handleError(args[0]);
-			else if (callback) callback.apply(null, args);
+			else if (callback) setImmediate(function () { callback.apply(null, args); });
 		}
 		// Call it cap'n.
 		try {
@@ -154,7 +154,7 @@ attempt.defaults = {
 	 * @type {Number}
 	 */
 	attempts: 0,
- 
+
 	/**
 	 * The maximum number of milliseconds to wait before retrying.  If the
 	 * interval or factor causes a wait time larger than 'max', 'max' will

--- a/test/lib.attempt.js
+++ b/test/lib.attempt.js
@@ -200,4 +200,26 @@ describe('Attempt', function() {
 				done();
 			});
 	});
+	it('should not handle throwing in final callback', function(done) {
+		var called = false;
+
+		// replace mocha's uncaughtException handler temporarily
+		var originalException = process.listeners('uncaughtException').pop();
+		//Needed in node 0.10.5+
+		process.removeListener('uncaughtException', originalException);
+		process.once('uncaughtException', function (error) {
+			process.listeners('uncaughtException').push(originalException);
+			done();
+		});
+
+		attempt(
+			function() {
+				this(null, 'success');
+			},
+			function callback(err, success) {
+				if (called) return done(new Error('Already called'));
+				called = true;
+				throw(new Error('Some Error'));
+			});
+	});
 });


### PR DESCRIPTION
This is only a problem if the users tryFunc fails
synchronously and thus calling the final callback in the
same callstack, which makes attempt() treat it just like
the tryFunc itself.