### PR TITLE
Another take on adding abort functionality

### DIFF
--- a/lib/attempt.js
+++ b/lib/attempt.js
@@ -106,6 +106,10 @@ function attempt(options, tryFunc, callback) {
 				}, 0);
 			}
 		}
+		// Check if abort was requested before retrying
+		if (options.abort()) {
+			return callback('Abort Requested');
+		}
 		// Call it cap'n.
 		try {
 			tryFunc.call(assess, options.attempts);
@@ -175,7 +179,16 @@ attempt.defaults = {
 	 * 150% of its original calculated time.
 	 * @type {Number}
 	 */
-	random: 0
+	random: 0,
+	
+	/**
+	 * An function to optionally be overwritten by the caller. If the abort
+	 * function returns true, execution of this attempt instance will be terminated
+	 * and the callback will be called immediately. Default function returns false
+	 * @type {Function}
+	 */
+	abort: function () { return false; }
+	
 };
 
 /**


### PR DESCRIPTION
I find the node-attempt module pretty useful, however as noted by someone else, the abort functionality is very much needed since sometimes further retries are either not necessary, or in my case, since I'm communicating with an external physical device, can be harmful (causing the other device to get stuck).
The proposed solution tries to adhere to the way the existing code is written by adding another optional function that can be set by the caller to attempt. This function is being called every time before the main function (tryFunc) is being called. If the abort function returns true, no more attempts will be made and the callback will be issued immediately with a specific error to indicate the abort.

Let me know what you think about this :)

btw, I tested it in my environment and it works just fine.
