### PR TITLE
Fix error encountered when only one arg is provided. Bump to v1.0.2.

### DIFF
--- a/lib/attempt.js
+++ b/lib/attempt.js
@@ -55,6 +55,8 @@ function attempt(options, tryFunc, callback) {
 	if (typeof options == 'function') {
 		callback = options;
 		options = {};
+	} else if (typeof options == 'undefined') {
+		options = {};
 	}
 	// Exit if we're done
 	if (options.retries && options.retries < 0) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Tom Frost <tom@frosteddesign.com>",
   "name": "attempt",
   "description": "Automatically retry functions that fail, in crazily customizable ways.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "homepage": "https://github.com/TomFrost/node-attempt",
   "repository": {
     "type": "git",

--- a/test/lib.attempt.js
+++ b/test/lib.attempt.js
@@ -2,6 +2,9 @@ var attempt = require('../lib/attempt.js'),
 	should = require('should');
 
 describe('Attempt', function() {
+	it('should only need a tryFunc', function (done) {
+		attempt(done);
+	});
 	it('should handle successful callbacks', function(done) {
 		attempt(
 			function() {


### PR DESCRIPTION
Encountered the following error when passing only a callback to attempt.

```
  1) Attempt should operate with only a callback:
     TypeError: Cannot read property 'retries' of undefined
      at attempt (lib/attempt.js:60:13)
      at Context.<anonymous> (test/lib.attempt.js:6:3)
```
